### PR TITLE
Fix launch.json to start chrome in a Sandbox

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,8 @@
             "webRoot": "${workspaceRoot}",
             
             //This line is important, since it instructs chrome to run in a separate, sandbox instance.
-            //This way, other running chrome instances won't prevent remote debugging from running.
-            "userDataDir": "C:\\temp\\chrom-dev-instance"
+            //This way, other running chrome instances won't prevent remote debugging from running.            
+            "userDataDir": "C:\\temp\\chrome-dev-instance"
         },
         {
             "name": "Attach to Chrome, with sourcemaps",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,11 @@
             "request": "launch",
             "url": "http://localhost:3000",
             "sourceMaps": true,
-            "webRoot": "${workspaceRoot}"
+            "webRoot": "${workspaceRoot}",
+            
+            //This line is important, since it instructs chrome to run in a separate, sandbox instance.
+            //This way, other running chrome instances won't prevent remote debugging from running.
+            "userDataDir": "C:\\temp\\chrom-dev-instance"
         },
         {
             "name": "Attach to Chrome, with sourcemaps",


### PR DESCRIPTION
Normally, the Debugger for Chrome requires all instances of Chrome to be closed, including background instances, before it can re-start Chrome with remote debugging enabled. This is extremely annoying if you're a google-file, have 50 tabs open, inbox, google drive and a dozen other chrome apps running - they all have to be shut.

Using this technique, you can instruct Chrome to start in a separate sandbox, with all settings saved to that temp path, and other processes won't be affected. Remote debugging will be enabled and you won't have to close your other instances. 

The one drawback of this is you'll have to install any other dev plugins again - but then you can always keep this 'sandbox' if you change the folder from 'temp' to another one.
